### PR TITLE
updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.5
+FROM alpine:3.14
 
-RUN apk upgrade --no-cache && apk add --no-cache bash curl ca-certificates
-RUN curl -L https://github.com/rlmcpherson/s3gof3r/releases/download/v0.5.0/gof3r_0.5.0_linux_amd64.tar.gz -o - | tar -xzf -; mv gof3r_0.5.0_linux_amd64/gof3r /bin; rm -rf gof3r_0.5.0_linux_amd64*
+RUN apk upgrade --no-cache && \
+	apk add --no-cache bash curl ca-certificates aws-cli gettext
 
 ADD ./s3cache /bin
 

--- a/s3cache
+++ b/s3cache
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
+set -e
+
+env_file="${PLUGIN_ENV_FILE:-.env}"
+if [[ -f "${env_file}" ]]; then
+  source "${env_file}"
+fi
 
 folders="${FOLDERS:-$PLUGIN_FOLDERS}"
 cache_bucket="${BUCKET:-$PLUGIN_BUCKET}"
 mode="${MODE:-$PLUGIN_MODE}"
 key="${PLUGIN_KEY:-$DRONE_REPO/$DRONE_BRANCH}"
-filename="${PLUGIN_FILENAME:-cache}"
+keys=${PLUGIN_KEYS}
 region="${AWS_REGION:-$PLUGIN_REGION}"
-
-set -e
+overwrite="${PLUGIN_OVERWRITE:-"true"}"
+s3_full_path=$(echo "s3://${cache_bucket}/${key}.tar.gz" | envsubst)
 
 if [[ -z "$cache_bucket" ]]; then
   echo "-- Error: no bucket specified"
@@ -19,28 +25,43 @@ if [[ -z "$region" ]]; then
   exit 1
 fi
 
-set +e
-
 case $mode in
     pull)
       echo "-- Pulling cache from S3..."
 
-      cd / && gof3r get -b $cache_bucket -k $key/$filename.tar \
-        --endpoint=s3-$region.amazonaws.com | tar -xf -
+      if [[ -z ${keys} ]]; then
+        if aws --region=${region} s3 ls ${s3_full_path} > /dev/null 2>&1; then
+          echo "found in cache: ${s3_full_path}"
+          cd / && aws --region=${region} s3 cp ${s3_full_path} - | tar -xzf -
+        else
+          echo "${s3_full_path} doesn't exists"
+        fi
+      else
+        for key in $(echo ${keys} | sed "s/,/ /g"); do
+          s3_full_path=$(echo "s3://${cache_bucket}/${key}.tar.gz" | envsubst)
+          if aws --region=${region} s3 ls ${s3_full_path} > /dev/null 2>&1; then
+            echo "found in cache: ${s3_full_path}"
+            cd / && aws --region=${region} s3 cp ${s3_full_path} - | tar -xzf -
+            echo "-- S3 cache $mode done!"
+            exit 0
+          else
+            echo "${s3_full_path} doesn't exists"
+          fi
+        done
+      fi
     ;;
+
     push)
       echo "-- Pushing cache to S3..."
 
-      cdirs=""
-      for f in $(echo $folders | tr -d '[[:space:]]' | tr "," "\n"); do
-        if [ -d $PWD/$f ]; then
-          cdirs="$cdirs $PWD/$f"
-        fi
-      done
-
-      tar -cf - $cdirs | gof3r put -b $cache_bucket -k $key/$filename.tar \
-        -m x-amz-server-side-encryption:AES256 --endpoint=s3-$region.amazonaws.com
+      if [[ ${overwrite} == "false" ]] && aws --region=${region} s3 ls ${s3_full_path} > /dev/null 2>&1; then
+        echo "${s3_full_path} already exists"
+        exit 0
+      else
+        tar -czf - ${folders//,/ } | aws --region=${region} s3 cp --sse aws:kms - ${s3_full_path}
+      fi
     ;;
+
     *)
       echo "-- Supported modes:
               pull - restore cache from S3.


### PR DESCRIPTION
hey, thanks for the plugin, have some improvements to consider:

* adds a way of having the s3 key dynamic through `.env` file
* removes the `filename` arg - `key` is enough
* adds `keys` list arg - similar to `CircleCi`:
  > When CircleCI encounters a list of keys, the cache will be restored from the first one matching an existing cache. Most probably you would want to have a more specific key to be first (for example, cache for exact version of package-lock.json file) and more generic keys after (for example, any cache for this project). If no key has a cache that exists, the step will be skipped with a warning.


* adds `overwrite` flag to not overwrite the same file
* switches to `aws-cli`
* bumps alpine version

usage:
```
- name: checksum_gemfile
  image: alpine:3.14
  commands:
  - echo "export GEMFILE_LOCK_SHA256=$(sha256sum Gemfile.lock | awk '{print $1}')" >> .env

- name: pull_cache
  image: docker.io/maciekm/drone-s3cache:latest
  settings:
    bucket: my-bucket
    region: eu-west-1
    mode: pull
    key: ${DRONE_REPO_NAME}/gems-$${GEMFILE_LOCK_SHA256}
  volumes:
  - name: bundle
    path: /usr/local/bundle

- name: bundle
  image: ruby:2.5
  commands:
  - bundle check || bundle install --binstubs --jobs 4 --retry 3 --without development
  volumes:
  - name: bundle
    path: /usr/local/bundle

- name: push_cache
  image: docker.io/maciekm/drone-s3cache:latest
  settings:
    bucket: my-bucket
    region: eu-west-1
    mode: push
    key: ${DRONE_REPO_NAME}/gems-$${GEMFILE_LOCK_SHA256}
    overwrite: false
    folders:
    - /usr/local/bundle
  volumes:
  - name: bundle
    path: /usr/local/bundle
```